### PR TITLE
Piece list in board

### DIFF
--- a/src/core/datatypes/Board.ts
+++ b/src/core/datatypes/Board.ts
@@ -21,6 +21,7 @@ type Layer = {
   seen: { [hash: string]: number };
   castles: CastleMap;
   moveCache: { [colors in Color]: Move[] | null };
+  pieceList: Coord[],
 };
 
 export type PriorState = {
@@ -82,6 +83,25 @@ export class Board {
       const color = spaceGetColor(space);
       const type = spaceGetType(space);
       attackMapAddPiece(this, idx, color, type);
+    }
+
+    // Update the piece list:
+    if ((prior === SPACE_EMPTY) !== (space === SPACE_EMPTY)) {
+      const list = this.current.pieceList;
+      if (prior === SPACE_EMPTY) {
+        // Piece added:
+        list.push(idx);
+      } else {
+        // Piece removed:
+        const pieceIdx = list.indexOf(idx);
+        const last = list.length - 1;
+        if (pieceIdx !== last) {
+          const temp = list[last];
+          list[last] = idx;
+          list[pieceIdx] = temp;
+        }
+        list.pop();
+      }
     }
   }
 
@@ -192,6 +212,7 @@ function newLayer(): Layer {
       [COLOR_WHITE]: null,
       [COLOR_BLACK]: null,
     },
+    pieceList: [],
   };
 }
 
@@ -207,4 +228,5 @@ function copyLayer(src: Layer, dest: Layer) {
   dest.castles = src.castles;
   dest.moveCache[COLOR_WHITE] = src.moveCache[COLOR_WHITE];
   dest.moveCache[COLOR_BLACK] = src.moveCache[COLOR_BLACK];
+  dest.pieceList = [...src.pieceList];
 }

--- a/src/core/datatypes/Board.ts
+++ b/src/core/datatypes/Board.ts
@@ -21,7 +21,7 @@ type Layer = {
   seen: { [hash: string]: number };
   castles: CastleMap;
   moveCache: { [colors in Color]: Move[] | null };
-  pieceList: Coord[],
+  pieceList: Coord[];
 };
 
 export type PriorState = {

--- a/src/core/datatypes/Board.ts
+++ b/src/core/datatypes/Board.ts
@@ -228,5 +228,5 @@ function copyLayer(src: Layer, dest: Layer) {
   dest.castles = src.castles;
   dest.moveCache[COLOR_WHITE] = src.moveCache[COLOR_WHITE];
   dest.moveCache[COLOR_BLACK] = src.moveCache[COLOR_BLACK];
-  dest.pieceList = [...src.pieceList];
+  dest.pieceList = src.pieceList.slice();
 }

--- a/src/core/logic/boardLacksMaterial.ts
+++ b/src/core/logic/boardLacksMaterial.ts
@@ -1,5 +1,5 @@
 import { Board } from "../datatypes/Board.ts";
-import { SPACE_EMPTY, spaceGetType } from "../datatypes/Space.ts";
+import { spaceGetType } from "../datatypes/Space.ts";
 import {
   PIECETYPE_BISHOP,
   PIECETYPE_KNIGHT,
@@ -29,37 +29,32 @@ export function boardLacksMaterial(b: Board): boolean {
   const counts = Array(8).fill(0);
   let bishopDiag = 0;
 
-  for (let rank = 0; rank < 0x80; rank += 0x10) {
-    for (let file = 0; file < 0x8; file++) {
-      const idx = rank | file;
+  for (const idx of b.current.pieceList) {
+    const spot = b.get(idx);
 
-      const spot = b.get(idx);
-      if (spot === SPACE_EMPTY) continue;
+    const type = spaceGetType(spot);
 
-      const type = spaceGetType(spot);
-
-      // Queens and rooks are strong enough that we can bail early if we encounter them. Pawns too, since none of the
-      // FIDE reasons for draw include pawns.
-      if (
-        type === PIECETYPE_PAWN || type === PIECETYPE_ROOK ||
-        type === PIECETYPE_QUEEN
-      ) {
-        return false;
-      }
-
-      count++;
-
-      // If a Bishop, we want to keep track of what tile color they're on:
-      if (type === PIECETYPE_BISHOP) {
-        const diag = ((idx >>> 4) ^ idx) & 1;
-        // Hack: We add all squares into the bishopDiag accumulator. We only care if all bishops are on the same color,
-        // so that variable will either be 0 or equal to the number of bishops.
-        bishopDiag += diag;
-      }
-
-      // Else, count it:
-      counts[type]++;
+    // Queens and rooks are strong enough that we can bail early if we encounter them. Pawns too, since none of the
+    // FIDE reasons for draw include pawns.
+    if (
+      type === PIECETYPE_PAWN || type === PIECETYPE_ROOK ||
+      type === PIECETYPE_QUEEN
+    ) {
+      return false;
     }
+
+    count++;
+
+    // If a Bishop, we want to keep track of what tile color they're on:
+    if (type === PIECETYPE_BISHOP) {
+      const diag = ((idx >>> 4) ^ idx) & 1;
+      // Hack: We add all squares into the bishopDiag accumulator. We only care if all bishops are on the same color,
+      // so that variable will either be 0 or equal to the number of bishops.
+      bishopDiag += diag;
+    }
+
+    // Else, count it:
+    counts[type]++;
   }
 
   // Only 2 kings:

--- a/src/core/logic/kingInDanger.ts
+++ b/src/core/logic/kingInDanger.ts
@@ -1,30 +1,21 @@
 import { Board } from "../datatypes/Board.ts";
 import { Color } from "../datatypes/Color.ts";
-import {
-  SPACE_EMPTY,
-  spaceGetColor,
-  spaceGetType,
-} from "../datatypes/Space.ts";
+import { spaceGetColor, spaceGetType } from "../datatypes/Space.ts";
 import { PIECETYPE_KING } from "../datatypes/PieceType.ts";
 import { attackMapIsAttacked } from "./attackMap.ts";
 
 export function kingInDanger(b: Board, kingColor: Color): boolean {
   const enemy = 8 - kingColor;
-  for (let rank = 0; rank < 0x80; rank += 0x10) {
-    for (let file = 0; file < 0x8; file++) {
-      const idx = rank | file;
+  for (const idx of b.current.pieceList) {
+    const spot = b.get(idx);
+    if (
+      spaceGetType(spot) !== PIECETYPE_KING || spaceGetColor(spot) !== kingColor
+    ) {
+      continue;
+    }
 
-      const spot = b.get(idx);
-      if (
-        spot === SPACE_EMPTY || spaceGetType(spot) !== PIECETYPE_KING ||
-        spaceGetColor(spot) !== kingColor
-      ) {
-        continue;
-      }
-
-      if (attackMapIsAttacked(b, idx, enemy)) {
-        return true;
-      }
+    if (attackMapIsAttacked(b, idx, enemy)) {
+      return true;
     }
   }
   return false;

--- a/src/core/logic/listValidMoves.ts
+++ b/src/core/logic/listValidMoves.ts
@@ -54,7 +54,7 @@ export function listAllValidMoves(
 ): Move[] {
   const cached = b.current.moveCache[color];
   if (cached) {
-    return [...cached];
+    return cached.slice();
   }
   const out: Move[] = [];
   for (const idx of b.current.pieceList) {

--- a/src/core/logic/listValidMoves.ts
+++ b/src/core/logic/listValidMoves.ts
@@ -57,13 +57,10 @@ export function listAllValidMoves(
     return [...cached];
   }
   const out: Move[] = [];
-  for (let rank = 0; rank < 0x80; rank += 0x10) {
-    for (let file = 0; file < 0x8; file++) {
-      const idx = rank | file;
-      const sp = b.get(idx);
-      if (sp !== SPACE_EMPTY && spaceGetColor(sp) === color) {
-        listValidMoves(b, idx, out);
-      }
+  for (const idx of b.current.pieceList) {
+    const sp = b.get(idx);
+    if (spaceGetColor(sp) === color) {
+      listValidMoves(b, idx, out);
     }
   }
   b.current.moveCache[color] = out;

--- a/test/board.test.ts
+++ b/test/board.test.ts
@@ -15,6 +15,7 @@ import {
   Space,
   spaceGetColor,
   spaceGetType,
+SPACE_EMPTY,
 } from "../src/core/datatypes/Space.ts";
 import { asserts } from "../testDeps.ts";
 
@@ -25,6 +26,23 @@ Deno.test("Board > Can set pieces", function () {
     encodePieceSpace(PIECETYPE_ROOK, COLOR_WHITE, false),
   );
   _assertSpace(b.get(buildCoord(2, 2)), PIECETYPE_ROOK, COLOR_WHITE);
+  asserts.assertEquals(b.current.pieceList, [0x22]);
+});
+
+Deno.test("Board > Can remove pieces", function () {
+  const b = new Board();
+  b.set(
+    buildCoord(2, 2),
+    encodePieceSpace(PIECETYPE_ROOK, COLOR_WHITE, false),
+  );
+  _assertSpace(b.get(buildCoord(2, 2)), PIECETYPE_ROOK, COLOR_WHITE);
+  asserts.assertEquals(b.current.pieceList, [0x22]);
+  b.set(
+    buildCoord(2, 2),
+    SPACE_EMPTY,
+  );
+  asserts.assertEquals(b.get(buildCoord(2, 2)), SPACE_EMPTY);
+  asserts.assertEquals(b.current.pieceList, []);
 });
 
 Deno.test("Board > Can add overlays", function () {
@@ -35,6 +53,7 @@ Deno.test("Board > Can add overlays", function () {
     encodePieceSpace(PIECETYPE_ROOK, COLOR_WHITE, false),
   );
   _assertSpace(b.get(buildCoord(2, 2)), PIECETYPE_ROOK, COLOR_WHITE);
+  asserts.assertEquals(b.current.pieceList, [0x22]);
 
   b.save();
   b.set(
@@ -42,6 +61,7 @@ Deno.test("Board > Can add overlays", function () {
     encodePieceSpace(PIECETYPE_QUEEN, COLOR_BLACK, false),
   );
   _assertSpace(b.get(buildCoord(2, 2)), PIECETYPE_QUEEN, COLOR_BLACK);
+  asserts.assertEquals(b.current.pieceList, [0x22]);
 });
 
 Deno.test("Board > Can remove overlays", function () {
@@ -52,6 +72,7 @@ Deno.test("Board > Can remove overlays", function () {
     encodePieceSpace(PIECETYPE_ROOK, COLOR_WHITE, false),
   );
   _assertSpace(b.get(buildCoord(2, 2)), PIECETYPE_ROOK, COLOR_WHITE);
+  asserts.assertEquals(b.current.pieceList, [0x22]);
 
   b.save();
   b.set(buildCoord(2, 2), 0);
@@ -59,6 +80,7 @@ Deno.test("Board > Can remove overlays", function () {
 
   b.restore();
   _assertSpace(b.get(buildCoord(2, 2)), PIECETYPE_ROOK, COLOR_WHITE);
+  asserts.assertEquals(b.current.pieceList, [0x22]);
 });
 
 function _assertSpace(sp: Space, t: PieceType, c: Color) {

--- a/test/board.test.ts
+++ b/test/board.test.ts
@@ -13,9 +13,9 @@ import {
 import {
   encodePieceSpace,
   Space,
+  SPACE_EMPTY,
   spaceGetColor,
   spaceGetType,
-SPACE_EMPTY,
 } from "../src/core/datatypes/Space.ts";
 import { asserts } from "../testDeps.ts";
 


### PR DESCRIPTION
Adds an array to keep track of piece positions in the board. The old logic would have to iterate the full board, and verify that spaces weren't equal to `SPACE_EMPTY` before handling the actual piece logic. Now, those places just have to iterate the precompiled piece list. This improves the `kingInDanger` method's performance quite a bit, and that offsets the extra overhead from maintaining the piece list. (Overall improvement is probably around 8%.)