### PR TITLE
Fix CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 os:
   - linux
-dist: xenial
+
+# Deno 1.18.1 accidentally broke xenial (nested dependency requires a newer glibc...)
+# So for now, target bionic beaver:
+dist: bionic
 
 # Deno not officially supported, so fall back on a generic image, and install ourselves:
 language: minimal


### PR DESCRIPTION
Seems that deno accidentally broke support on older linux distros, since a dependency of a dependency used a method only available in newer versions of glibc. (See: denoland/deno#13516)

This PR bumps the CI distro to be "bionic beaver" to side-step that issue, and get the build healthy again.