### PR TITLE
Add getSpace method to query the board

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,19 @@ Most of the game features are provided by the ChessGame class.
 
   The game was drawn. A reason can be provided.
 
+### Checking on the board
+
+- **`game.getSpace(coord: string)`**
+
+  Will return an object that describes a space on the board. Has these
+  properties:
+  - `coord`: the space's coordinate.
+  - `piece`: an object describing the piece. Only included if a piece is here.
+    Properties:
+    - `color`: the piece's color. (Either `"white"` or `"black"`.)
+    - `pieceType`: the piece's type. (One of: `"P"`, `"B"`, `"N"`, `"R"`, `"Q"`,
+      or `"K"`.)
+
 ### Tags
 
 Keeping tags for your game can be useful when exporting in PGN format. By

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Some things that I plan on getting to:
 
 - [ ] Slightly better AI.
 - [ ] Openings database. (Probably available as a separate module, to keep the
-  main module size small.)
+      main module size small.)
 - [ ] Ability to connect with UCI-compatible engines.
 
 ## License

--- a/scripts/chess.ts
+++ b/scripts/chess.ts
@@ -93,8 +93,10 @@ function printGame(game: ChessGame) {
     const turn = history[line];
     if (turn) {
       const numStr = turn.num + ".";
-      turnStr = `${numStr.padEnd(4)} ${turn.white.padEnd(7)} ${turn.black ||
-        "..."}`;
+      turnStr = `${numStr.padEnd(4)} ${turn.white.padEnd(7)} ${
+        turn.black ||
+        "..."
+      }`;
     }
     console.log(board[line], " ", turnStr);
   }

--- a/scripts/utilities/tourney.ts
+++ b/scripts/utilities/tourney.ts
@@ -159,7 +159,7 @@ function competeAIs(fen: string): [number, number] {
 
   console.log(
     "- Checkmate (%s win) in %d ms",
-    (status.turn === "white" ? "black" : "white"),
+    status.turn === "white" ? "black" : "white",
     Date.now() - start,
   );
 

--- a/src/autoplayers/utils/gameScore.ts
+++ b/src/autoplayers/utils/gameScore.ts
@@ -9,7 +9,6 @@ export const MATE = 10;
  * |-----------|-----------------|--------------------|-----|------------------|-----------------|
  * | Logically | -M1 .... -M1000 | -2^32 ... -1       |  0  | 1 ... 2^32       | +M1000 ... +M1  |
  *
- *
  * Basically, there is a line (currently drawn at +/- 2**32) that separates standard move scores and checkmate scores.
  * Also note that checkmates are reversed, since we prefer a mate in 3 moves over a mate in 20.
  */

--- a/src/public/ChessGame.ts
+++ b/src/public/ChessGame.ts
@@ -22,7 +22,11 @@ import {
   GAMESTATUS_DRAW_STALEMATE,
   GAMESTATUS_RESIGNED,
 } from "../core/datatypes/GameStatus.ts";
-import { SPACE_EMPTY, spaceGetColor } from "../core/datatypes/Space.ts";
+import {
+  SPACE_EMPTY,
+  spaceGetColor,
+  spaceGetType,
+} from "../core/datatypes/Space.ts";
 import { boardFromFEN } from "../core/logic/FEN/boardFromFEN.ts";
 import { doGameMove } from "./doGameMove.ts";
 import { GameMove, GameMoveInternal } from "./GameMove.ts";
@@ -87,6 +91,31 @@ interface MoveDetails {
    * If this move is a promotion, this parameter will be included to indicate what the pawn is promoting to.
    */
   promotion?: "B" | "N" | "R" | "Q";
+}
+
+/**
+ * Details for a space on the board.
+ */
+interface SpaceDetails {
+  /**
+   * The space's coordinate.
+   */
+  coord: string;
+
+  /**
+   * Details on the piece located on this space. Omitted if no piece is located here.
+   */
+  piece?: {
+    /**
+     * The piece's color.
+     */
+    color: "white" | "black";
+
+    /**
+     * The piece's type.
+     */
+    pieceType: "P" | "B" | "N" | "R" | "Q" | "K";
+  };
 }
 
 /**
@@ -178,6 +207,30 @@ export class ChessGame {
       game.#gameWinner = data.winner;
     }
     return game;
+  }
+
+  /**
+   * Get info about a specific board coordinate. The coordinate must be in algebraic notation.
+   *
+   * @param coord The space's coordinate. (eg: "f3")
+   */
+  getSpace(coord: string): SpaceDetails {
+    const idx = coordFromAN(coord);
+    const sp = this.#board.get(idx);
+    const details: SpaceDetails = { coord };
+    if (sp !== SPACE_EMPTY) {
+      details.piece = {
+        color: spaceGetColor(sp) === COLOR_WHITE ? "white" : "black",
+        pieceType: pieceTypeLetter(spaceGetType(sp)) as
+          | "P"
+          | "B"
+          | "N"
+          | "R"
+          | "Q"
+          | "K",
+      };
+    }
+    return details;
   }
 
   /**

--- a/test/ChessGame.test.ts
+++ b/test/ChessGame.test.ts
@@ -160,6 +160,26 @@ Deno.test("ChessGame Public API > List a promotion", function () {
   ]);
 });
 
+Deno.test("ChessGame Public API > Can query the board", function () {
+  const game = ChessGame.NewStandardGame();
+  game.move("e2e4");
+  asserts.assertEquals(game.getSpace("e2"), { coord: "e2" });
+  asserts.assertEquals(game.getSpace("e4"), {
+    coord: "e4",
+    piece: {
+      color: "white",
+      pieceType: "P",
+    },
+  });
+  asserts.assertEquals(game.getSpace("h8"), {
+    coord: "h8",
+    piece: {
+      color: "black",
+      pieceType: "R",
+    },
+  });
+});
+
 Deno.test("ChessGame Public API > Can move", function () {
   const game = ChessGame.NewStandardGame();
   game.move("e2e4");
@@ -350,7 +370,7 @@ Deno.test("ChessGame Public API > Draws after 50 moves", function () {
       game.move((i % 2 === 1) ? "d8d7" : "d7d8");
     }
     for (let i = 5; i > 2; i--) {
-      game.move(coordToAN((i * 0x10)) + coordToAN((i * 0x10 - 0x10)));
+      game.move(coordToAN(i * 0x10) + coordToAN(i * 0x10 - 0x10));
       game.move((i % 2 === 0) ? "d8d7" : "d7d8");
     }
     // Avoid repetition fails:


### PR DESCRIPTION
Adds a new getSpace method to the ChessGame class, that lets you check on the status of the board's spaces.

```ts
const game = ChessGame.NewStandardGame();

game.getSpace("b4");
// { coord: "b2" }

game.getSpace("h8");
// {
//   coord: "h8",
//   piece: {
//     color: "black",
//     pieceType: "R",
//   },
// }
```